### PR TITLE
✨ svaba init

### DIFF
--- a/tools/svaba.cwl
+++ b/tools/svaba.cwl
@@ -19,11 +19,11 @@ inputs:
   blacklist: { type: 'File?', inputBinding: { prefix: '--blacklist', position: 0 }, doc: "BED-file with blacklisted regions to not extract any reads from." }
   germline_sv_database: { type: 'File?', inputBinding: { prefix: '--germline-sv-database', position: 0 }, doc: "BED file containing sites of known germline SVs. Used as additional filter for somatic SV detection." }
 
-  gzip: { type: 'boolean?', default: true, inputBinding: { valueFrom: "$(self ? '--g-zip' : '')", position: 0 }, doc: "Gzip and tabix the output VCF files." }
-  germline: { type: 'boolean?', default: false, inputBinding: { valueFrom: "$(self ? '--germline' : '')", position: 0}, doc: "Sets recommended settings for case-only analysis (eg germline). (-I, -L5, assembles NM >= 3 reads)" }
+  gzip: { type: 'boolean?', default: true, inputBinding: { prefix: '--g-zip', position: 0 }, doc: "Gzip and tabix the output VCF files." }
+  germline: { type: 'boolean?', default: false, inputBinding: { prefix: '--germline', position: 0}, doc: "Sets recommended settings for case-only analysis (eg germline). (-I, -L5, assembles NM >= 3 reads)" }
   rules: { type: 'boolean?', default: false, inputBinding: { valueFrom: "$(self ? '--rules all' : '')", position: 0 }, doc: "Default behavior is just assemble clipped/discordant/unmapped/gapped reads. Override?" }
-  highly_parallel: { type: 'boolean?', default: false, inputBinding: { valueFrom: "$(self ? '--hp' : '')", position: 0 }, doc: "Highly parallel. Don't write output until completely done. More memory, but avoids all thread-locks." }
-  no_interchrom_lookup: { type: 'boolean?', default: false, inputBinding: { valueFrom: "$(self ? '--no-interchrom-lookup' : '')", position: 0 }, doc: "Set true to not do mate-region lookup if mates are mapped to different chromosome." }
+  highly_parallel: { type: 'boolean?', default: false, inputBinding: { prefix: '--hp', position: 0 }, doc: "Highly parallel. Don't write output until completely done. More memory, but avoids all thread-locks." }
+  no_interchrom_lookup: { type: 'boolean?', default: false, inputBinding: { prefix: '--no-interchrom-lookup', position: 0 }, doc: "Set true to not do mate-region lookup if mates are mapped to different chromosome." }
 
   mate_lookup_min: { type: 'int?', inputBinding: { prefix: '--mate-lookup-min', position: 0 }, doc: "Minimum number of somatic reads required to attempt mate-region lookup" }
 
@@ -31,10 +31,10 @@ inputs:
   cores: { type: 'int?', default: 8, inputBinding: { prefix: '--threads', position: 0 }, doc: "Use NUM threads to run svaba." }
   ram: { type: 'int?', default: 8, doc: "Minimum ram to allocate to the task." }
 outputs:
-  alignments: { type: 'File', outputBinding: { glob: $(inputs.output_basename).alignments.txt.gz } }
-  bps: { type: 'File', outputBinding: { glob: $(inputs.output_basename).bps.txt.gz } }
-  configs: { type: 'File', outputBinding: { glob: $(inputs.output_basename).contigs.bam } }
-  log: { type: 'File', outputBinding: { glob: $(inputs.output_basename).log } }
+  alignments: { type: 'File', outputBinding: { glob: $(inputs.output_basename).alignments.txt.gz }, doc: "An ASCII plot of variant-supporting contigs and the BWA-MEM alignment of reads to the contigs" }
+  bps: { type: 'File', outputBinding: { glob: $(inputs.output_basename).bps.txt.gz }, doc: "Raw, unfiltered variants" }
+  contigs: { type: 'File', outputBinding: { glob: $(inputs.output_basename).contigs.bam }, doc: "All assembly contigs as aligned to the reference with BWA-MEM" }
+  log: { type: 'File', outputBinding: { glob: $(inputs.output_basename).log }, doc: "Log file giving run-time information, including CPU and Wall time (and how it was partitioned among the tasks), number of reads retrieved and contigs assembled for each region" }
   germline_indel_vcf_gz: { type: 'File?', outputBinding: { glob: "$(inputs.output_basename).svaba.$(inputs.normal_bams ? 'germline.' : '')indel.vcf.gz" }, secondaryFiles: [.tbi] }
   germline_indel_unfiltered_vcf_gz: { type: 'File?', outputBinding: { glob: "$(inputs.output_basename).svaba.unfiltered.$(inputs.normal_bams ? 'germline.' : '')indel.vcf.gz" }, secondaryFiles: [.tbi] }
   germline_sv_vcf_gz: { type: 'File?', outputBinding: { glob: "$(inputs.output_basename).svaba.$(inputs.normal_bams ? 'germline.' : '')sv.vcf.gz" }, secondaryFiles: [.tbi] }


### PR DESCRIPTION
Adds Svaba tool to the repo.

Can be run both as:
Germline: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/a2de471c-5b94-45d2-ba4e-b5a5b87fcf62/
Somatic: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/203743b0-fb38-4514-85f8-2e8338df60c3/

The somatic runs do produce their own germline files. Germline runs only produce the germline files but they don't call them germline. Might want to look into this more.

One thought revolving around the gzip option. I currently account for the option of gzipping by having two sets of outputs (vcf and vcf_gz). Considered different options but the secondary files made with the gzipped files really made that not possible (optional secondaryFiles in cwl v1.1 !).

Another thought would be that the lists of inputs is not exhaustive. I just tried to grab what I thought we might potentially use. Also running `--help` on the tool is a liar. The true list of options is seen here: https://github.com/walaj/svaba/blob/master/src/svaba/run_svaba.cpp#L195-L250.

I tested the highly parallel option: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/f5128292-c4e0-4b0b-b0df-9cc6015a836a/ and it seemed to do worse both in ram usage and time compared to not using it: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/5bc93674-1153-46d0-9049-1d817c1e4349/ 

Part of: https://github.com/d3b-center/bixu-tracker/issues/787