### PR TITLE
🐳 dockerPull from new registry

### DIFF
--- a/tools/bcftools_concat.cwl
+++ b/tools/bcftools_concat.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: ${ return inputs.ram * 1000 }
     coresMin: $(inputs.cpu)
   - class: DockerRequirement
-    dockerPull: 'kfdrc/vcfutils:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/vcfutils:latest'
 
 baseCommand: []
 arguments:

--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -12,7 +12,7 @@ requirements:
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
   - class: DockerRequirement
-    dockerPull: 'kfdrc/bwa:0.7.17-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa:0.7.17-r1188'
   - class: InlineJavascriptRequirement
 baseCommand: []
 arguments:

--- a/tools/freebayes.cwl
+++ b/tools/freebayes.cwl
@@ -39,7 +39,7 @@ requirements:
               return text
           }
   - class: DockerRequirement
-    dockerPull: 'kfdrc/freebayes:v1.3.2'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/freebayes:v1.3.2'
 
 baseCommand: [freebayes, --bam-list, bams.txt]
 

--- a/tools/gatk_applyrecalibration.cwl
+++ b/tools/gatk_applyrecalibration.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_applyrecalibration
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_gatherfinalvcf.cwl
+++ b/tools/gatk_gatherfinalvcf.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_gathervcfs
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_gathertranches.cwl
+++ b/tools/gatk_gathertranches.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_gathertranches
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: ResourceRequirement
     ramMin: 7000

--- a/tools/gatk_gathervcfs.cwl
+++ b/tools/gatk_gathervcfs.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_gathervcfs
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_import_genotype_filtergvcf_merge.cwl
+++ b/tools/gatk_import_genotype_filtergvcf_merge.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_import_genotype_filtergvcf_merge
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_indelsvariantrecalibrator.cwl
+++ b/tools/gatk_indelsvariantrecalibrator.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_indelsvariantrecalibrator
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_indexfeaturefile.cwl
+++ b/tools/gatk_indexfeaturefile.cwl
@@ -4,7 +4,7 @@ id: gatk_indexfeaturefile
 doc: "Creates an index for a feature file, e.g. VCF or BED file."
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_file),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/gatk_intervallisttool.cwl
+++ b/tools/gatk_intervallisttool.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.1.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.1.0'
   - class: ResourceRequirement
     ramMin: 2000
 

--- a/tools/gatk_mergevcfs.cwl
+++ b/tools/gatk_mergevcfs.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.1.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.1.0'
   - class: ResourceRequirement
     ramMin: 4000
     coresMin: 2

--- a/tools/gatk_selectvariants.cwl
+++ b/tools/gatk_selectvariants.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: ${ return inputs.max_memory * 1000 }
     coresMin: $(inputs.cpu)
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
 baseCommand: [/gatk]
 arguments:
   - position: 1

--- a/tools/gatk_snpsvariantrecalibratorcreatemodel.cwl
+++ b/tools/gatk_snpsvariantrecalibratorcreatemodel.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_snpsvariantrecalibratorcreatemodel
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_snpsvariantrecalibratorscattered.cwl
+++ b/tools/gatk_snpsvariantrecalibratorscattered.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_snpsvariantrecalibratorscattered
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_variantfiltration.cwl
+++ b/tools/gatk_variantfiltration.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: ${ return inputs.max_memory * 1000 }
     coresMin: $(inputs.cpu)
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
 baseCommand: [/gatk]
 arguments:
   - position: 1

--- a/tools/kfdrc_peddy_tool.cwl
+++ b/tools/kfdrc_peddy_tool.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 1000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/peddy:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/peddy:latest'
 baseCommand: [python]
 arguments:
   - position: 1

--- a/tools/manta.cwl
+++ b/tools/manta.cwl
@@ -10,7 +10,7 @@ requirements:
     ramMin: ${ return inputs.ram * 1000 }
     coresMin: $(inputs.cores)
   - class: DockerRequirement
-    dockerPull: 'kfdrc/manta:1.6.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/manta:1.6.0'
 
 baseCommand: [/manta-1.6.0.centos6_x86_64/bin/configManta.py]
 arguments:

--- a/tools/picard_collectvariantcallingmetrics.cwl
+++ b/tools/picard_collectvariantcallingmetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ResourceRequirement
     ramMin: 7000
     coresMin: 8

--- a/tools/picard_createsequencedictionary.cwl
+++ b/tools/picard_createsequencedictionary.cwl
@@ -7,7 +7,7 @@ doc: |-
   The tool returnts the dict as its only output.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_dict)]
   - class: InlineJavascriptRequirement

--- a/tools/samtools_faidx.cwl
+++ b/tools/samtools_faidx.cwl
@@ -7,7 +7,7 @@ doc: |-
   Finally the tool will return the input reference file with the index (generated or provided) as a secondaryFile.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/script_dynamicallycombineintervals.cwl
+++ b/tools/script_dynamicallycombineintervals.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: script_dynamicallycombineintervals
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/python:2.7.13'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/python:2.7.13'
   - class: InlineJavascriptRequirement
 hints:
   - class: 'sbg:AWSInstanceType'

--- a/tools/smoove_lumpy.cwl
+++ b/tools/smoove_lumpy.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: ${return inputs.cores * 2000}
     coresMin: $(inputs.cpus)
   - class: DockerRequirement
-    dockerPull: 'kfdrc/smoove:0.2.5'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/smoove:0.2.5'
 baseCommand: ["/bin/bash", "-c"]
 arguments:
   - position: 1

--- a/tools/strelka2_germline.cwl
+++ b/tools/strelka2_germline.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: ${ return inputs.ram * 1000 }
     coresMin: $(inputs.cores)
   - class: DockerRequirement
-    dockerPull: 'kfdrc/strelka:v2.9.10'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/strelka:v2.9.10'
 
 baseCommand: [/strelka-2.9.10.centos6_x86_64/bin/configureStrelkaGermlineWorkflow.py, --runDir=./]
 arguments:

--- a/tools/svaba.cwl
+++ b/tools/svaba.cwl
@@ -4,7 +4,7 @@ id: svaba
 requirements:
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/svaba:1.1.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/svaba:1.1.0'
   - class: ResourceRequirement
     ramMin: $(inputs.ram)
     coresMin: $(inputs.cores)

--- a/tools/tabix_index.cwl
+++ b/tools/tabix_index.cwl
@@ -6,7 +6,7 @@ doc: >-
   The tool will output the input_file with the index, provided or created within, as a secondary file.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_file),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/variant_effect_predictor.cwl
+++ b/tools/variant_effect_predictor.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: 24000
     coresMin: 14
   - class: DockerRequirement
-    dockerPull: 'kfdrc/vep:r93'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/vep:r93'
 baseCommand: [tar, -xzf ]
 arguments:
   - position: 1


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR updates the dockerPulls to draw from the new registry.
It also updates the docker image for bwa to one that exists in the bixtools repo.
Before we merge vcfutils doesn't have a docker image in the new registry, needed.

Part of https://github.com/d3b-center/bixu-tracker/issues/846

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] No but it's not really important at the moment since these aren't production.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
