### PR TITLE
✏️ allow `tool_name` to do the heavy lifting

### DIFF
--- a/workflows/kfdrc-germline-snv-annot-workflow.cwl
+++ b/workflows/kfdrc-germline-snv-annot-workflow.cwl
@@ -365,8 +365,8 @@ steps:
           \ return [self[i],self[i].secondaryFiles[0]]; } } }"
       rename_to:
         source: [output_basename, tool_name]
-        valueFrom: "${var pro_vcf=self[0] + '.' + self[1] + '.norm.annot.vcf.gz';\
-          \ var pro_tbi=self[0] + '.' + self[1] + '.norm.annot.vcf.gz.tbi'; return\
+        valueFrom: "${var pro_vcf=self[0] + '.' + self[1] + '.vcf.gz';\
+          \ var pro_tbi=self[0] + '.' + self[1] + '.vcf.gz.tbi'; return\
           \ [pro_vcf, pro_tbi];}"
     out: [renamed_files]
 

--- a/workflows/kfdrc-germline-snv-annot-workflow.cwl
+++ b/workflows/kfdrc-germline-snv-annot-workflow.cwl
@@ -377,6 +377,6 @@ sbg:license: Apache License 2.0
 sbg:publisher: KFDRC
 
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-germline-workflow/releases/tag/v0.4.1'
+- id: 'https://github.com/kids-first/kf-germline-workflow/releases/tag/v0.4.2'
   label: github-release
 

--- a/workflows/kfdrc-single-sample-genotyping-wf.cwl
+++ b/workflows/kfdrc-single-sample-genotyping-wf.cwl
@@ -362,5 +362,5 @@ hints:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-germline-workflow/releases/tag/v0.4.1'
+- id: 'https://github.com/kids-first/kf-germline-workflow/releases/tag/v0.4.2'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Bix-Ops has requested to drop the `norm.annot` from the rename step and let the tool_name do the heavy lifting for suffix. This will help keep it consistent with previous efforts.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] All of these tasks: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-bhjxbdqk-x01-gatk-hc-gvcf-wgs-germline/tasks?search=Kids%20First%20DRC%20Germline%20Workflow%20run
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
