### PR TITLE
✨  plink init

### DIFF
--- a/subworkflows/plink.cwl
+++ b/subworkflows/plink.cwl
@@ -1,0 +1,65 @@
+cwlVersion: v1.2
+class: Workflow
+id: plink
+doc: |
+  Plink subworkflow. Loads a VCF then runs genome and sexchecks on it.
+requirements:
+- class: ScatterFeatureRequirement
+- class: MultipleInputFeatureRequirement
+- class: InlineJavascriptRequirement
+- class: StepInputExpressionRequirement
+inputs:
+  input_vcf: { type: 'File' }
+  input_ped: { type: 'File?' }
+  output_basename: {type: 'string', doc: "String value to use as basename for outputs"}
+
+  genome: { type: ['null', { type: enum, name: "genome", symbols: ["base", "gz", "rel-check", "full", "unbounded", "nudge"]}], doc: "invokes an IBS/IBD computation. The 'full' modifier adds additional fields. The 'gz' modifier causes the output to be gzipped, while 'rel-check' removes pairs of samples with different FIDs.  The 'unbounded' modifier turns off clipping. Nudge 'nudge' modifier adjusts the final estimates" }
+
+  # Resource Requirements
+  plink_cpu: {type: 'int?', doc: "CPUs to allocate to plink"}
+  plink_ram: {type: 'int?', doc: "RAM in GB to allocate to plink"}
+
+outputs:
+  genome_out: {type: 'File?', outputSource: plink_process_binary/genome_out }
+  sexcheck_out: {type: 'File', outputSource: plink_process_binary/sexcheck_out }
+
+steps:
+  plink_load_variant_file:
+    run: ../tools/plink_load_variant_file.cwl
+    in:
+      input_vcf: input_vcf
+      output_basename: output_basename
+      const_fid:
+        valueFrom: "placeholder"
+      cpu: plink_cpu
+      ram: plink_ram
+    out: [bim, bed, fam, log, skip_3allele]
+
+  awk_reorder_ped_for_plink:
+    run: ../tools/awk_reorder_ped_for_plink.cwl
+    when: $(inputs.input_ped != null)
+    in:
+      input_fam: plink_load_variant_file/fam
+      input_ped: input_ped
+    out: [output_fam]
+
+  plink_process_binary:
+    run: ../tools/plink_process_binary.cwl
+    in:
+      input_bim: plink_load_variant_file/bim
+      input_bed: plink_load_variant_file/bed
+      input_fam:
+        source: [awk_reorder_ped_for_plink/output_fam, plink_load_variant_file/fam]
+        pickValue: first_non_null
+      output_basename: output_basename
+      genome: genome
+      check_sex:
+        valueFrom: "base"
+      cpu: plink_cpu
+      ram: plink_ram
+    out: [genome_out, sexcheck_out, mendel_out, catchall_out]
+
+$namespaces:
+  sbg: https://sevenbridges.com
+"sbg:license": Apache License 2.0
+"sbg:publisher": KFDRC

--- a/tools/awk_reorder_ped_for_plink.cwl
+++ b/tools/awk_reorder_ped_for_plink.cwl
@@ -1,0 +1,26 @@
+cwlVersion: v1.2
+class: CommandLineTool
+id: awk_ped_to_fam
+doc: |
+  Use the fam from plink to properly order the provided PED file.
+  Return the output as a fam for use with future plink steps.
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+baseCommand: []
+arguments:
+  - position: 1
+    shellQuote: false
+    valueFrom: >
+      awk '{print $2}' $(inputs.input_fam.path)
+      | while read line;
+      do awk -v var="$line" '$2 == var {print $0}' $(inputs.input_ped.path) >> $(inputs.input_fam.basename);
+      done
+inputs:
+  input_fam: { type: 'File' }
+  input_ped: { type: 'File' }
+outputs:
+  output_fam:
+    type: File
+    outputBinding:
+      glob: '*.fam'

--- a/tools/plink_load_variant_file.cwl
+++ b/tools/plink_load_variant_file.cwl
@@ -1,0 +1,69 @@
+class: CommandLineTool
+cwlVersion: v1.2
+id: plink_load_variant_file
+doc: |-
+  Create a plink file from a VCF/BCF
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: 'pgc-images.sbgenomics.com/danmiller/plink:1.90-b7.2'
+  - class: ResourceRequirement
+    ramMin: $(inputs.ram*1000)
+    coresMin: $(inputs.cpu)
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >
+      plink
+inputs:
+  input_vcf: { type: 'File?', inputBinding: { position: 2, prefix: "--vcf" }, doc: "Input VCF file. Can be bgzipped." }
+  input_bcf: { type: 'File?', inputBinding: { position: 2, prefix: "--bcf" }, doc: "Input BCF file. Can be bgzipped." }
+  output_basename: { type: 'string?', default: "plink", inputBinding: { position: 2, prefix: "--out"}, doc: "Basename for plink binary files." }
+  double_id: { type: 'boolean?', inputBinding: { position: 2, prefix: "--double-id" }, doc: "causes both family and within-family IDs to be set to the sample ID" }
+  const_fid: { type: 'string?', inputBinding: { position: 2, prefix: "--const-fid" }, doc: "converts sample IDs to within-family IDs while setting all family IDs to a single value" }
+  id_delim: { type: 'string?', inputBinding: { position: 2, prefix: "--id-delim" }, doc: "causes sample IDs to be parsed as <FID><delimiter><IID>" }
+  vcf_idspace_to: { type: 'string?', inputBinding: { position: 2, prefix: "--vcf-idspace-to" }, doc: "convert all spaces in sample IDs to this character" }
+  biallelic_only: { type: ['null', { type: enum, name: "biallelic_only", symbols: ["base", "strict", "list"] }], inputBinding: { position: 2, prefix: "--biallelic-only", shellQuote: false, valueFrom: "$(self == 'base' ? '' : self)"}, doc: "Use to skip all variants where at least two alternate alleles are present in the dataset. The 'strict' mode will indiscriminately skip variants with 2+ alternate alleles listed even when only one alternate allele actually shows up. The 'list' mode will dump a list of skipped variant IDs to plink.skip.3allele." }
+  vcf_min_qual: { type: 'float?', inputBinding: { position: 2, prefix: "--vcf-min-qual" }, doc: "causes all variants with QUAL value smaller than the given number, or with no QUAL value at all, to be skipped" }
+  vcf_filter: { type: 'string[]?', inputBinding: { position: 2, prefix: "--vcf-filter" }, doc: "skip variants which failed one or more filters tracked by the FILTER field" }
+  vcf_require_gt: { type: 'boolean?', inputBinding: { position: 2, prefix: "--vcf-require-gt" }, doc: "Skip variants with missing GT fields." }
+  vcf_min_gp: { type: 'float?', inputBinding: { position: 2, prefix: "--vcf-min-gp" }, doc: "excludes all genotype calls with GP value below the given threshold" }
+  vcf_min_gq: { type: 'float?', inputBinding: { position: 2, prefix: "--vcf-min-gq" }, doc: "excludes all genotype calls with GQ below the given (nonnegative, decimal values permitted) threshold" }
+  vcf_half_call: { type: ['null', { type: enum, name: "vcf_half_call", symbols: ["error", "haploid", "missing", "reference"]}], inputBinding: { position: 2, prefix: "--vcf-half-call" }, doc: "specify how '0/.' and similar GT values should be interpreted. Error: PLINK 1.9 errors out and reports the line number of the anomaly. Haploid: Treat half-calls as haploid/homozygous. Missing: Treat half-calls as missing. Reference: Treat the missing part as reference." }
+
+  cpu:
+    type: 'int?'
+    default: 4
+    doc: "Number of CPUs to allocate to this task."
+  ram:
+    type: 'int?'
+    default: 8
+    doc: "GB size of RAM to allocate to this task."
+
+outputs:
+  bim:
+    type: File
+    outputBinding:
+      glob: '*.bim'
+  bed:
+    type: File
+    outputBinding:
+      glob: '*.bed'
+  fam:
+    type: File
+    outputBinding:
+      glob: '*.fam'
+  log:
+    type: File
+    outputBinding:
+      glob: '*.log'
+  skip_3allele:
+    type: File?
+    outputBinding:
+      glob: '*.skip.3allele'
+  catchall_out:
+    type: File[]?
+    outputBinding:
+      glob: $(inputs.output_basename)*

--- a/tools/plink_process_binary.cwl
+++ b/tools/plink_process_binary.cwl
@@ -1,0 +1,64 @@
+class: CommandLineTool
+cwlVersion: v1.2
+id: plink_process_binary
+doc: |-
+  Process a plink binary file
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: 'pgc-images.sbgenomics.com/danmiller/plink:1.90-b7.2'
+  - class: ResourceRequirement
+    ramMin: $(inputs.ram*1000)
+    coresMin: $(inputs.cpu)
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >
+      plink
+inputs:
+  input_bed: { type: 'File', inputBinding: { position: 2, prefix: "--bed" }, doc: "Binary BED file for plink." }
+  input_bim: { type: 'File', inputBinding: { position: 2, prefix: "--bim" }, doc: "Binary BIM file for plink." }
+  input_fam: { type: 'File', inputBinding: { position: 2, prefix: "--fam" }, doc: "Binary FAM file for plink." }
+  output_basename: { type: 'string?', default: "plink", inputBinding: { position: 2, prefix: "--out"}, doc: "Basename for plink binary files." }
+
+  # GENOME
+  genome: { type: ['null', { type: enum, name: "genome", symbols: ["base", "gz", "rel-check", "full", "unbounded", "nudge"]}], inputBinding: { position: 2, prefix: "--genome", shellQuote: false, valueFrom: "$(self == 'base' ? '' : self)" }, doc: "invokes an IBS/IBD computation. The 'full' modifier adds additional fields. The 'gz' modifier causes the output to be gzipped, while 'rel-check' removes pairs of samples with different FIDs.  The 'unbounded' modifier turns off clipping. Nudge 'nudge' modifier adjusts the final estimates" }
+  ppc_gap: { type: 'int?', inputBinding: { position: 2, prefix: "--ppc-gap" }, doc: "minimum distance between informative pairs of SNPs used in the pairwise population concordance (PPC) test in kilobases" }
+  min_pi_hat: { type: 'float?', inputBinding: { position: 2, prefix: "--min" }, doc: "Minimum pi hat value to be included in the final output." }
+  max_pi_hat: { type: 'float?', inputBinding: { position: 2, prefix: "--max" }, doc: "Maximum pi hat value to be included in the final output." }
+
+  # SEX CHECK
+  check_sex: { type: ['null', { type: enum, name: "check_sex", symbols: ["base", "ycount", "y-only"]}], inputBinding: { position: 2, prefix: "--check-sex", shellQuote: false, valueFrom: "$(self == 'base' ? '' : self)" }, doc: "compares sex assignments in the input dataset with those imputed from X chromosome inbreeding coefficients. In 'ycount' mode, gender is still imputed from the X chromosome, but female calls are downgraded to ambiguous whenever more than 0 nonmissing Y genotypes are present, and male calls are downgraded when fewer than 0 are present. In 'y-only' mode, gender is imputed from nonmissing Y genotype counts, and the X chromosome is ignored." }
+
+  # MENDEL and more
+  mendel: { type: ['null', { type: enum, name: "mendel", symbols: ["base", "summaries-only"]}], inputBinding: { position: 2, prefix: "--mendel", valueFrom: "$(self == 'base' ? '' : self)" }, doc: "scans the dataset for Mendel errors. If you only want summary statistics, use the 'summaries-only' modifier." }
+  additional_args: { type: 'string[]?', inputBinding: { position: 2, shellQuote: false }, doc: "Any additonal args for plink. There are a lot..." }
+
+  cpu:
+    type: 'int?'
+    default: 4
+    doc: "Number of CPUs to allocate to this task."
+  ram:
+    type: 'int?'
+    default: 8
+    doc: "GB size of RAM to allocate to this task."
+
+outputs:
+  genome_out:
+    type: File?
+    outputBinding:
+      glob: '*.genome'
+  sexcheck_out:
+    type: File?
+    outputBinding:
+      glob: '*.sexcheck'
+  mendel_out:
+    type: File[]?
+    outputBinding:
+      glob: '*{.mendel,.imendel,.fmendel,.lmendel}'
+  catchall_out:
+    type: File[]?
+    outputBinding:
+      glob: $(inputs.output_basename)*


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Adds Plink tools and workflow.
- Workflow takes the VCF and converts it to plink format
- Then it uses the FAM file to properly order the PED file
- Using the PED file it checks the sex and relatedness of the individual

When run for a single sample, the genome option needs to be turned off. There cannot be a comparison with only one sample.

Part of https://github.com/d3b-center/bixu-tracker/issues/2297

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Solo: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/a73c1140-600f-49d2-9827-d9ca6ac713d6/#
- [x] Joint: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/9fa6ea40-370f-497a-8739-dfa96e0f4411/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
