### PR TITLE
:wrench: GenomicsDBImport extra args init

### DIFF
--- a/tools/gatk_import_genotype_filtergvcf_merge.cwl
+++ b/tools/gatk_import_genotype_filtergvcf_merge.cwl
@@ -21,7 +21,6 @@ arguments:
       -L $(inputs.interval.path)
       --reader-threads 16
       -ip 5
-      $(inputs.genomicsdbimport_extra_args != null ? inputs.genomicsdbimport_extra_args : '')
   - position: 2
     shellQuote: false
     valueFrom: >-
@@ -73,7 +72,11 @@ inputs:
     secondaryFiles: [.tbi]
     inputBinding:
       position: 1
-  genomicsdbimport_extra_args: string?
+  genomicsdbimport_extra_args:
+    type: string?
+    inputBinding:
+      position: 1
+      shellQuote: false
 outputs:
   variant_filtered_vcf:
     type: File

--- a/tools/gatk_import_genotype_filtergvcf_merge.cwl
+++ b/tools/gatk_import_genotype_filtergvcf_merge.cwl
@@ -21,6 +21,7 @@ arguments:
       -L $(inputs.interval.path)
       --reader-threads 16
       -ip 5
+      $(inputs.genomicsdbimport_extra_args != null ? inputs.genomicsdbimport_extra_args : '')
   - position: 2
     shellQuote: false
     valueFrom: >-
@@ -72,6 +73,7 @@ inputs:
     secondaryFiles: [.tbi]
     inputBinding:
       position: 1
+  genomicsdbimport_extra_args: string?
 outputs:
   variant_filtered_vcf:
     type: File

--- a/workflows/kfdrc-germline-snv-wf.cwl
+++ b/workflows/kfdrc-germline-snv-wf.cwl
@@ -236,6 +236,7 @@ inputs:
   indel_max_gaussians: {type: 'int?', doc: "Interger value for max gaussians in INDEL VariantRecalibration. If a dataset gives fewer
       variants than the expected scale, the number of Gaussians for training should be turned down. Lowering the max-Gaussians forces
       the program to group variants into a smaller number of clusters, which results in more variants per cluster."}
+  genomicsdbimport_extra_args: {type: 'string?', doc: "Any extra arguments to give to GenomicsDBImport" }
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
@@ -453,6 +454,7 @@ steps:
       wgs_evaluation_interval_list: wgs_evaluation_interval_list
       snp_max_gaussians: snp_max_gaussians
       indel_max_gaussians: indel_max_gaussians
+      genomicsdbimport_extra_args: genomicsdbimport_extra_args
       output_basename: output_basename
       tool_name:
         valueFrom: "single.vqsr.filtered.vep_105"

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -357,6 +357,7 @@ inputs:
   indel_max_gaussians: {type: 'int?', doc: "Interger value for max gaussians in INDEL VariantRecalibration. If a dataset gives fewer
       variants than the expected scale, the number of Gaussians for training should be turned down. Lowering the max-Gaussians forces
       the program to group variants into a smaller number of clusters, which results in more variants per cluster."}
+  genomicsdbimport_extra_args: {type: 'string?', doc: "Any extra arguments to give to GenomicsDBImport" }
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
@@ -579,6 +580,7 @@ steps:
       ped: ped
       snp_max_gaussians: snp_max_gaussians
       indel_max_gaussians: indel_max_gaussians
+      genomicsdbimport_extra_args: genomicsdbimport_extra_args
       bcftools_annot_clinvar_columns: bcftools_annot_clinvar_columns
       clinvar_annotation_vcf: clinvar_annotation_vcf
       echtvar_anno_zips: echtvar_anno_zips

--- a/workflows/kfdrc-single-sample-genotyping-wf.cwl
+++ b/workflows/kfdrc-single-sample-genotyping-wf.cwl
@@ -93,6 +93,7 @@ inputs:
   indel_max_gaussians: {type: 'int?', doc: "Interger value for max gaussians in INDEL VariantRecalibration. If a dataset gives fewer
       variants than the expected scale, the number of Gaussians for training should be turned down. Lowering the max-Gaussians forces
       the program to group variants into a smaller number of clusters, which results in more variants per cluster."}
+  genomicsdbimport_extra_args: {type: 'string?', doc: "Any extra arguments to give to GenomicsDBImport" }
   output_basename: string
   tool_name: {type: 'string?', default: "single.vqsr.filtered.vep_105", doc: "File name string suffx to use for output files"}
   # Annotation
@@ -142,6 +143,7 @@ steps:
       interval: dynamicallycombineintervals/out_intervals
       dbsnp_vcf: dbsnp_vcf
       reference_fasta: indexed_reference_fasta
+      genomicsdbimport_extra_args: genomicsdbimport_extra_args
     scatter: [interval]
     out: [variant_filtered_vcf, sites_only_vcf]
   gatk_gathervcfs:


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Add extra args for GenomicsDBImport. Will allow OPs to update `--genomicsdb-vcf-buffer-size` option for failures.

Closes https://d3b.atlassian.net/browse/BIXU-3799

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/d3b-bixu-ops/sd-z7r9svga-alignment-harmonization-target-normal/tasks/e90db880-276b-4e5f-aeb8-e27b5b4f1a1e/stats/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
